### PR TITLE
Add CellBender v3 support to read_cellbender() function

### DIFF
--- a/sctk/_read.py
+++ b/sctk/_read.py
@@ -249,7 +249,7 @@ def read_cellbender_v3(f,
     import scipy.sparse as sp
     import pandas as pd
     cols = ["cell_probability", "droplet_efficiency"]
-    if "barcode_indices_for_latents" in f["droplet_latents"]:
+    if f['droplet_latents']['barcode_indices_for_latents'].shape[0] < n_obs:
         bidx = f["droplet_latents"]["barcode_indices_for_latents"][()]
         obsdict = {}
         for x in cols:
@@ -263,7 +263,7 @@ def read_cellbender_v3(f,
             obsm.fill(np.nan)
             obsm[bidx, :] = lge
     else:
-        obsdict = {x: f["matrix"][x] for x in cols}
+        obsdict = {x: f["droplet_latents"][x] for x in cols}
         if latent_gene_encoding:
             obsm = f["droplet_latents"]["gene_expression_encoding"][()]
     barcodes = np.array(

--- a/sctk/_read.py
+++ b/sctk/_read.py
@@ -139,11 +139,11 @@ def read_cellbender(
             vardict=vardict,
             n_var=n_var,
             n_obs=n_obs,
-            remove_zero=True,
-            remove_nan=True,
-            train_history=False,
-            latent_gene_encoding=False,
-            add_suffix=None,)
+            remove_zero=remove_zero,
+            remove_nan=remove_nan,
+            train_history=train_history,
+            latent_gene_encoding=latent_gene_encoding,
+            add_suffix=add_suffix,)
     else:
         ad = read_cellbender_v2(mat,
             feat=feat,
@@ -151,11 +151,11 @@ def read_cellbender(
             vardict=vardict,
             n_var=n_var,
             n_obs=n_obs,
-            remove_zero=True,
-            remove_nan=True,
-            train_history=False,
-            latent_gene_encoding=False,
-            add_suffix=None,)
+            remove_zero=remove_zero,
+            remove_nan=remove_nan,
+            train_history=train_history,
+            latent_gene_encoding=latent_gene_encoding,
+            add_suffix=add_suffix,)
     return ad
 
 def read_cellbender_v2(mat,
@@ -280,7 +280,7 @@ def read_cellbender_v3(f,
             "target_false_positive_rate": f['metadata']["target_false_positive_rate"][()],
             "test_elbo": list(f['metadata']['learning_curve_test_elbo']),
             "test_epoch": list(f['metadata']['learning_curve_test_epoch']),
-            "overall_change_in_train_elbo": list(f['metadata']["overall_change_in_train_elbo"]),
+            # "overall_change_in_train_elbo": list(f['metadata']["overall_change_in_train_elbo"]), this doesn't exist in default h5 v3
         }
         if train_history
         else {},


### PR DESCRIPTION
Hello,

CellBender v3 made some big changes on how the h5 outputs are organised, and also some keys have been renamed. So I modified `read_cellbender()` function to support v3 outputs. I used the same structure the original `read_cellbender()` function has. My changes might not be very suitable to how the package was structured, so please feel free to make any changes on my PR.

Actually, CellBender v3 added a new function to read their h5's in their Python package, you can check their docs [here](https://cellbender.readthedocs.io/en/latest/tutorial/index.html#use-output-count-matrix-in-downstream-analyses). But I thought that would be better if sctk has v3 support too.

Best,
Batu